### PR TITLE
Fix data loading error in info-frame

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-16T15:42:13.927Z for PR creation at branch issue-2-226d132f2f8f for issue https://github.com/Muriam/cpp_and_other/issues/2

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-16T15:42:13.927Z for PR creation at branch issue-2-226d132f2f8f for issue https://github.com/Muriam/cpp_and_other/issues/2

--- a/js/issue/script.js
+++ b/js/issue/script.js
@@ -5,7 +5,7 @@ const cityInfoDiv = document.getElementById('city-info');
 // Функция для загрузки HTML файла города
 async function loadCityHTML(cityName) {
     try {
-        const response = await fetch(`cities/${cityName}.html`);
+        const response = await fetch(`data/${cityName}.html`);
         
         if (!response.ok) {
             throw new Error(`HTTP ошибка: ${response.status}`);
@@ -28,7 +28,7 @@ async function showCityInfo(cityName) {
             <div style="color: red; padding: 20px;">
                 <h3>Ошибка загрузки данных</h3>
                 <p>Не удалось загрузить информацию о городе "${cityName}"</p>
-                <p>Проверьте файл: cities/${cityName}.html</p>
+                <p>Проверьте файл: data/${cityName}.html</p>
             </div>
         `;
         return;


### PR DESCRIPTION
## Summary

- Fixes the "Ошибка загрузки данных" (data loading error) shown in the `info-frame` div
- Root cause: `script.js` was fetching city HTML files from `cities/${cityName}.html`, but the actual files are stored in the `data/` directory
- Fix: Updated the fetch path from `cities/` to `data/`

## How to reproduce

1. Open `js/issue/index.html` in a browser (via a local server)
2. Click on "Веллингтон" or "Тауранга"
3. Before fix: red error "Ошибка загрузки данных" appears
4. After fix: city information is displayed correctly

## Changes

- `js/issue/script.js`: corrected fetch path from `cities/${cityName}.html` to `data/${cityName}.html`

Closes #2